### PR TITLE
Fix Python 3.13 compatibility: replace distutils with shutil

### DIFF
--- a/thefuck/system/unix.py
+++ b/thefuck/system/unix.py
@@ -3,7 +3,7 @@ import sys
 import tty
 import termios
 import colorama
-from distutils.spawn import find_executable
+from shutil import which as find_executable
 from .. import const
 
 init_output = colorama.init


### PR DESCRIPTION
- Replace 'from distutils.spawn import find_executable' with 'from shutil import which as find_executable'
- The distutils module was removed in Python 3.12+, causing ModuleNotFoundError
- shutil.which is the recommended replacement and provides identical functionality

This complements the existing importlib fixes for the 'imp' module in conf.py