### PR TITLE
♻️ refactor(unix): replace deprecated distutils.spawn with shutil.which

### DIFF
--- a/thefuck/system/unix.py
+++ b/thefuck/system/unix.py
@@ -3,8 +3,12 @@ import sys
 import tty
 import termios
 import colorama
-from distutils.spawn import find_executable
+# from distutils.spawn import find_executable
 from .. import const
+import shutil
+
+def find_executable(name):
+    return shutil.which(name)
 
 init_output = colorama.init
 


### PR DESCRIPTION
- remove deprecated distutils.spawn import
- add shutil import
- implement find_executable using shutil.which for better compatibility